### PR TITLE
Silent Starts, Session IDs, Current Duration

### DIFF
--- a/Sources/Boop/Boop.swift
+++ b/Sources/Boop/Boop.swift
@@ -21,6 +21,10 @@ public class Boop {
     public var isDisabled: Bool
     /// If `true`, disables the booping of sessions (including those that might be automatically booped based on other event activity)
     public var isSessionTrackingDisabled: Bool
+    /// Toggles whether or not to actually send "Session Start" events to Firebase
+    ///
+    /// Defaults to `true` meaning the session start events are sent to Firebase. If `false`, you should still call ``trackSessionStart()`` in order to get a recording of the session duration when ``trackSessionStop()`` is called.
+    public var isSendingSessionStartEvents: Bool
     
     /// Set this value to automatically subtract the duration of an inactivity timeout when booping sessions. Defaults to `0`.
     public var sessionTimeout: TimeInterval
@@ -31,7 +35,15 @@ public class Boop {
     private var sessionStart: Date?
     private let logSubsystem: String = "tv.sticky.boop"
     
-    public init(application: String, instance: String = "default", isDevelopment: Bool = true, isDisabled: Bool = true, isSessionTrackingDisabled: Bool = false, sessionTimeout: TimeInterval = 0, firebaseConfigPath: String? = nil) {
+    public init(application: String,
+                instance: String = "default",
+                isDevelopment: Bool = true,
+                isDisabled: Bool = true,
+                isSessionTrackingDisabled: Bool = false,
+                isSendingSessionStartEvents: Bool = true,
+                sessionTimeout: TimeInterval = 0,
+                firebaseConfigPath: String? = nil
+    ) {
         let log = Logger(subsystem: logSubsystem, category: "init")
         
         var filePath: String? = firebaseConfigPath
@@ -62,6 +74,7 @@ public class Boop {
         self.instance = instance
         self.sessionTimeout = sessionTimeout
         self.isSessionTrackingDisabled = isSessionTrackingDisabled
+        self.isSendingSessionStartEvents = isSendingSessionStartEvents
         self.didSessionStart = self.isSessionTrackingDisabled
     }
     
@@ -117,7 +130,7 @@ public class Boop {
         let value = Int(self.sessionTimeout * 1000)
         self.sessionStart = Date()
         self.didSessionStart = true
-        return self.trackEvent(event: "Session Start", label: label, value: value)
+        return self.isSendingSessionStartEvents ? self.trackEvent(event: "Session Start", label: label, value: value) : nil
     }
     
     public func trackSessionStop() -> DocumentReference? {

--- a/Sources/Boop/Boop.swift
+++ b/Sources/Boop/Boop.swift
@@ -25,7 +25,6 @@ public class Boop {
     ///
     /// Defaults to `true` meaning the session start events are sent to Firebase. If `false`, you should still call ``trackSessionStart()`` in order to get a recording of the session duration when ``trackSessionStop()`` is called.
     public var isSendingSessionStartEvents: Bool
-    
     /// Set this value to automatically subtract the duration of an inactivity timeout when booping sessions. Defaults to `0`.
     public var sessionTimeout: TimeInterval
     /// This value is internally flipped during the very first user-initiated event in order to ensure the first session (after app launch) includes a starting boop.
@@ -33,6 +32,14 @@ public class Boop {
     /// You can enable it immediately after instantiating Boop in order to prevent this "first session start" behavior. Disabling session boops with ``isSessionTrackingDisabled`` will also prevent the "first session start" behavior.
     public var didSessionStart: Bool
     private var sessionStart: Date?
+    /// The current time (in seconds) since the start of the session, or `0`
+    public var currentSessionDuration: TimeInterval {
+        var value: TimeInterval = 0
+        if self.didSessionStart, let sessionStart = self.sessionStart {
+            value = Date().timeIntervalSince(sessionStart) - self.sessionTimeout
+        }
+        return value
+    }
     private var sessionId: UUID?
     private let logSubsystem: String = "tv.sticky.boop"
     
@@ -157,11 +164,7 @@ public class Boop {
             label += " (minus Timeout delay)"
         }
         
-        var value = 0
-        if let sessionStart = self.sessionStart {
-            value = Int((Date().timeIntervalSince(sessionStart) - self.sessionTimeout) * 1000)
-        }
-        
+        let value = Int(self.currentSessionDuration * 1000)
         return self.trackEvent(event: "Session Stop", label: label, value: value, isUserInitiated: false)
     }
 }

--- a/Tests/BoopTests/BoopTests.swift
+++ b/Tests/BoopTests/BoopTests.swift
@@ -144,7 +144,7 @@ final class BoopTests: XCTestCase {
         let stopData = stopDoc.data()
         XCTAssertNotNil(stopData)
         let stopId = stopData?["sessionId"] as? String
-
+        
         // make sure start and stop ids are the same
         XCTAssertEqual(startId, stopId)
         
@@ -194,5 +194,32 @@ final class BoopTests: XCTestCase {
         
         let stopRef = TEST?.trackSessionStop()
         XCTAssertNil(stopRef)
+    }
+    
+    func testSessionDuration() async throws {
+        TEST?.isSessionTrackingDisabled = false
+        let startRef = TEST?.trackSessionStart()
+        XCTAssertNotNil(startRef)
+        
+        XCTAssertNotNil(TEST?.currentSessionDuration)
+        XCTAssertLessThan(TEST?.currentSessionDuration ?? 0, 1.0)
+        
+        // Wait for 1 second
+        try await Task.sleep(until: .now + .seconds(1.0))
+        
+        XCTAssertGreaterThanOrEqual(TEST?.currentSessionDuration ?? 0, 1.0)
+        
+        let stopRef = TEST?.trackSessionStop()
+        XCTAssertNotNil(stopRef)
+        
+        let document = try await stopRef!.getDocument()
+        XCTAssertNotNil(document)
+        let data = document.data()
+        XCTAssertNotNil(data)
+        
+        // Check session duration in milliseconds from the document
+        let durationMs = data?["value"] as? Double
+        XCTAssertNotNil(durationMs)
+        XCTAssertGreaterThanOrEqual(durationMs ?? 0, 1000.0)
     }
 }

--- a/Tests/BoopTests/BoopTests.swift
+++ b/Tests/BoopTests/BoopTests.swift
@@ -79,6 +79,14 @@ final class BoopTests: XCTestCase {
         XCTAssertEqual("Session Start", outputEvent)
     }
     
+    func testSessionStartSilent() async throws {
+        TEST?.isSendingSessionStartEvents = false
+        TEST?.isSessionTrackingDisabled = false
+        TEST?.didSessionStart = false
+        let ref = TEST?.trackSessionStart()
+        XCTAssertNil(ref)
+    }
+    
     func testSessionStop() async throws {
         TEST?.isSessionTrackingDisabled = false
         TEST?.didSessionStart = true

--- a/Tests/BoopTests/BoopTests.swift
+++ b/Tests/BoopTests/BoopTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import FirebaseFirestore
 @testable import Boop
 
 var TEST: Boop? = nil
@@ -22,6 +23,10 @@ final class BoopTests: XCTestCase {
                 firebaseConfigPath: path
             )
         }
+        let settings = FirestoreSettings()
+        settings.cacheSettings = MemoryCacheSettings()
+        Firestore.firestore().settings = settings
+        Firestore.firestore().clearPersistence()
     }
     
     func testEvent() async throws {


### PR DESCRIPTION
"Session Start" events were a nice-to-have feature when we did not trust Firebase's ability to recover events during a network outage. We trust that more now and are considering migrating toward a system that will only publish a single event with all session-related data when the session ends. This is the first step which makes sending of the "Session Start" event optional.

This change could be paired with the new `currentSessionDuration` property to prevent submitting a "Session Stop" event if the session duration is deemed below a target threshold.

Finally, we are adding `sessionId` to the tracked object which will make it much easier to group events per session.