### PR TITLE
Session Flops

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ A convenience class for submitting events (boops) to a Firestore Database. Stick
    let boop = Boop(application: "my-application", firebaseConfigPath: path)
    ```
 
+   See documentation in Xcode for more configuration options.
+
 1. Make boops.
 
    ```swift
@@ -48,7 +50,12 @@ A convenience class for submitting events (boops) to a Firestore Database. Stick
    | Field | Type | |
    | --- | --- | --- |
    | `instance` | `String` | Distinguishes multiple instances of the application, if needed |
-   | `event` | `String` | `Session Start`, `Session Stop`, `App Launch` or whatever |
+   | `sessionId` | `UUID` | For grouping session data[^1]. Refreshed whenever `trackSessionStart()` is called |
+   | `event` | `String` | "Session Start", "Session Stop", "Session Flop"[^2], "App Launch" or whatever |
    | `label` | `String?` | Optional, maybe it classifies the `value`? |
    | `value` | `Any?` | Whatever you want |
    | `timestamp` | `FirebaseFirestore.Timestamp` | When it happened (UTC) |
+
+[^1]: Boop assumes session events occur synchronously on one device. It is not intended for tracking multiple, simultaneous sessions on one device.
+
+[^2]: A "Session Flop" event is recorded when a session does not meet the minimum duration threshold as configured by the `minimumViableSessionDuration` property. You can disable recording these events by setting `minimumViableSessionDuration` to `nil` or `isSendingSessionFlopEvents` to `false`.

--- a/Sources/Boop/Boop.swift
+++ b/Sources/Boop/Boop.swift
@@ -187,6 +187,7 @@ public class Boop {
                 return nil
             }
             event = "Session Flop"
+            label += " (below minimum threshold)"
         }
         return self.trackEvent(event: event, label: label, value: value, isUserInitiated: false)
     }

--- a/Tests/BoopTests/BoopTests.swift
+++ b/Tests/BoopTests/BoopTests.swift
@@ -14,18 +14,14 @@ final class BoopTests: XCTestCase {
         let path = bundle.path(forResource: "GoogleService-Info", ofType: "plist")
         XCTAssertNotNil(path)
         
-        if TEST == nil {
-            TEST = Boop(
-                application: "sticky-boop-swift",
-                instance: "xcode-test",
-                isDevelopment: true,
-                isDisabled: false,
-                firebaseConfigPath: path
-            )
-        }
-        let settings = FirestoreSettings()
-        settings.cacheSettings = MemoryCacheSettings()
-        Firestore.firestore().settings = settings
+        TEST = nil
+        TEST = Boop(
+            application: "sticky-boop-swift",
+            instance: "xcode-test",
+            isDevelopment: true,
+            isDisabled: false,
+            firebaseConfigPath: path
+        )
         Firestore.firestore().clearPersistence()
     }
     

--- a/Tests/BoopTests/BoopTests.swift
+++ b/Tests/BoopTests/BoopTests.swift
@@ -31,7 +31,6 @@ final class BoopTests: XCTestCase {
         let inputLabel = UUID().uuidString
         let inputValue = UUID().uuidString
         
-        TEST?.isSessionTrackingDisabled = false
         TEST?.didSessionStart = true
         let ref = TEST?.trackEvent(event: inputEvent, label: inputLabel, value: inputValue)
         
@@ -66,9 +65,6 @@ final class BoopTests: XCTestCase {
     }
     
     func testSessionStart() async throws {
-        TEST?.isSessionTrackingDisabled = false
-        TEST?.didSessionStart = false
-        TEST?.isSendingSessionStartEvents = true
         let ref = TEST?.trackSessionStart()
         
         let document = try await ref!.getDocument()
@@ -83,14 +79,11 @@ final class BoopTests: XCTestCase {
     
     func testSessionStartSilent() async throws {
         TEST?.isSendingSessionStartEvents = false
-        TEST?.isSessionTrackingDisabled = false
-        TEST?.didSessionStart = false
         let ref = TEST?.trackSessionStart()
         XCTAssertNil(ref)
     }
     
     func testSessionStop() async throws {
-        TEST?.isSessionTrackingDisabled = false
         TEST?.didSessionStart = true
         let ref = TEST?.trackSessionStop()
         
@@ -107,8 +100,6 @@ final class BoopTests: XCTestCase {
     
     /// Simulates 2 sessions. Each start and stop of a session should have the same `sessionId`, but the `sessionId` between 2 sessions should be different
     func testSessionId() async throws {
-        TEST?.isSessionTrackingDisabled = false
-        TEST?.didSessionStart = false
         let startRef = TEST?.trackSessionStart()
         let startDoc = try await startRef!.getDocument()
         XCTAssertNotNil(startDoc)
@@ -194,7 +185,6 @@ final class BoopTests: XCTestCase {
     }
     
     func testSessionDuration() async throws {
-        TEST?.isSessionTrackingDisabled = false
         let startRef = TEST?.trackSessionStart()
         XCTAssertNotNil(startRef)
         
@@ -222,7 +212,6 @@ final class BoopTests: XCTestCase {
     
     func testSessionFlop() async throws {
         let minimum = 1.0
-        TEST?.isSessionTrackingDisabled = false
         TEST?.minimumViableSessionDuration = minimum
                 
         let startRef = TEST?.trackSessionStart()


### PR DESCRIPTION
Adds a `minimumViableSessionDuration` property, which if set with a TimeInterval value, will send "Session Flop" events instead of "Session Stop" events for any session with a duration that does not exceed the value.
Also adds `isSendingSessionFlopEvents` Bool property which can be used to silence the sending of "Session Flop" events if they are not desired.